### PR TITLE
Fixed link to "best practices" chapter in chapter 2

### DIFF
--- a/walkthrough.Rmd
+++ b/walkthrough.Rmd
@@ -83,7 +83,7 @@ Ozone,Solar.R,Wind,Temp,Month,Day
 ...
 ```
 
-`functions.R` contains our custom user-defined functions. (See the [best practices chapter](#practice) for a discussion of function-oriented workflows.)
+`functions.R` contains our custom user-defined functions. (See the [best practices chapter](#practices) for a discussion of function-oriented workflows.)
 
 ```{r, eval = FALSE}
 # functions.R


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Summary
The link was not working because the id of the "best practices" chapter is "practices", but the link was pointing to the id "practice".


# Related GitHub issues and pull requests

* Ref: #

# Checklist

* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
