### PR TITLE
Update hpc.Rmd: make required location of future::plan more explicit

### DIFF
--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -191,7 +191,7 @@ install.packages("future.callr")
 ### Future locally
 
 To parallelize targets over multiple processes on your local machine, declare a  `future` plan in your `_targets.R` file. The `callr` plan from the  [`future.callr`](https://future.callr.futureverse.org) package is recommended.^[Some alternative local future plans are [listed here](https://github.com/HenrikBengtsson/future/#controlling-how-futures-are-resolved).]
-It is crucial that `future::plan(...)` is called in the `_targets.R` file itself - defining a plan interactively before invoking `tar_make_future(...)` does not leverage the future package.
+It is crucial that `future::plan()` is called in the `_targets.R` file itself - defining a plan interactively before invoking `tar_make_future()` does not leverage the future package.
 
 ```{r, eval = FALSE}
 # _targets.R

--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -191,6 +191,7 @@ install.packages("future.callr")
 ### Future locally
 
 To parallelize targets over multiple processes on your local machine, declare a  `future` plan in your `_targets.R` file. The `callr` plan from the  [`future.callr`](https://future.callr.futureverse.org) package is recommended.^[Some alternative local future plans are [listed here](https://github.com/HenrikBengtsson/future/#controlling-how-futures-are-resolved).]
+It is crucial that `future::plan(...)` is called in the `_targets.R` file itself - defining a plan interactively before invoking `tar_make_future(...)` does not leverage the future package.
 
 ```{r, eval = FALSE}
 # _targets.R


### PR DESCRIPTION
added note on the slightly counter intuitive need to declare the future plan in _targets.R

# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Summary

I struggled a while to figure out that the location of the call to `future::plan` is absolutely crucial (must be in _targets.R). This is documented but not made explicit enough. 

# Related GitHub issues and pull requests

* https://github.com/ropensci/targets/discussions/426#discussioncomment-641382

# Checklist

* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
