### PR TITLE
Fix faulty hyperlink n Chapter 2.4

### DIFF
--- a/walkthrough.Rmd
+++ b/walkthrough.Rmd
@@ -152,7 +152,7 @@ and `tar_visnetwork()`.
 tar_visnetwork()
 ```
 
-Both graphing functions above visualize the underlying directed acyclic graph (DAG) and tell you how targets are connected. This DAG is indifferent to the order of targets in your pipeline. You will still get the same graph even if you rearrange them. This is because `targets` uses static code analysis to detect the dependencies of each target, and this process does not depend on target order. For details, visit the [dependency detection section of the best practices guide](https://books.ropensci.org/targets/practice.html#dependencies).
+Both graphing functions above visualize the underlying directed acyclic graph (DAG) and tell you how targets are connected. This DAG is indifferent to the order of targets in your pipeline. You will still get the same graph even if you rearrange them. This is because `targets` uses static code analysis to detect the dependencies of each target, and this process does not depend on target order. For details, visit the [dependency detection section of the best practices guide](https://books.ropensci.org/targets/practices.html#dependencies).
 
 ## Run the pipeline
 


### PR DESCRIPTION
Add the missing "s" in the hyperlink directing to Chapter 6.3

# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Summary

The purpose of the pull request is to perform the faulty hyperlink fix.

# Related GitHub issues and pull requests

* Ref: #50 

# Checklist

* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
