### PR TITLE
Fix output file example

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -60,6 +60,7 @@ create_output <- function(file) {
   data <- read.csv(file)
   output <- head(data)
   write.csv(output, "output.csv")
+  "output.csv"
 }
 list(
   tar_target(name = input, command = "data.csv", format = "file"),


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ ] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

# Summary

With targets 0.12.0 (current release) this example throws an error, making the output function return the path fixes it.
```
> tar_make()
• start target input
• built target input
• start target output
x error target output
• end pipeline: 0.22 seconds
Error in tar_throw_run(target$metrics$error) : 
  _build_ target output did not return a character. dynamic files (targets with format = "file") must return character vectors of file or directory paths.
```
