### PR TITLE
Update hpc.Rmd - fixing broken links

### DIFF
--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -61,7 +61,7 @@ The following sections cover the mechanics and configuration details of high-per
 
 ### Clustermq installation
 
-Persistent workers require the [`clustermq`](https://github.com/mschubert/clustermq) R package, which in turn requires [ZeroMQ](http://zeromq.org/). Please refer to the [`clustermq` installation guide](https://github.com/mschubert/clustermq/blob/main/README.md#installation) for specific instructions.
+Persistent workers require the [`clustermq`](https://github.com/mschubert/clustermq) R package, which in turn requires [ZeroMQ](http://zeromq.org/). Please refer to the [`clustermq` installation guide](https://github.com/mschubert/clustermq/blob/master/README.md#installation) for specific instructions.
 
 ### Clustermq locally
 
@@ -91,7 +91,7 @@ tar_make_clustermq(workers = 2)
 For parallel computing on a cluster,
 
 1. Choose a [scheduler listed here](https://mschubert.github.io/clustermq/articles/userguide.html#configuration) that corresponds to your cluster's resource manager.
-1. Create a [template file](https://github.com/mschubert/clustermq/tree/main/inst) that configures the computing requirements and other settings for the cluster.
+1. Create a [template file](https://github.com/mschubert/clustermq/tree/master/inst) that configures the computing requirements and other settings for the cluster.
 
 Supply the scheduler option and template file to the `clustermq.scheduler` and `clustermq.template` global options in your target script file (default: `_targets.R`).
 


### PR DESCRIPTION
Updates clustermq links, as the repo uses 'master' as the default branch, current links 404.

# Prework

* [ ] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ ] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
^ This link in the issue template needs to be updated from `https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md` to `https://github.com/ropensci-books/targets-manual/blob/main/CONTRIBUTING.md`
(boooks)
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.
^ Typo so probably not needed, but I can make one if required.

# Related GitHub issues and pull requests

* Ref: #

# Summary

Please explain the purpose and scope of your contribution.

Fixing broken links.
