### PR TITLE
Fix missing comma

### DIFF
--- a/debugging.qmd
+++ b/debugging.qmd
@@ -89,7 +89,7 @@ Even if you hit an error, you can still finish the successful parts of the pipel
 # _targets.R
 library(targets)
 tar_option_set(
-  packages = c("broom", "broom.mixed", "dplyr", "nlme", "tibble", "tidyr")
+  packages = c("broom", "broom.mixed", "dplyr", "nlme", "tibble", "tidyr"),
   error = "null" # produce a result even if the target errored out.
 )
 


### PR DESCRIPTION
# Prework

* [X] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [X] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #

# Summary

Execution of example code failed. Fixed by adding a comma to separate arguments.
