### PR TITLE
Fixes #71

### DIFF
--- a/markdown.qmd
+++ b/markdown.qmd
@@ -3,7 +3,7 @@ execute:
   freeze: auto
 ---
 
-# Target Markdown {.appendix}
+# Target Markdown {#markdown}
 
 ```{r, message = FALSE, warning = FALSE, echo = FALSE, eval = TRUE}
 knitr::opts_knit$set(root.dir = fs::dir_create(tempfile()))


### PR DESCRIPTION
# Related GitHub issues and pull requests

* Ref: #71 

# Summary

I added the heading hash identifier (`#markdown`) to `markdown.qmd` so that internal hyperlinks are correctly generated for HTML rendering.