### PR TITLE
Change phrasing to not imply targets checks hashes by default

### DIFF
--- a/performance.qmd
+++ b/performance.qmd
@@ -151,7 +151,7 @@ If `seconds_meta_append` is 15, then `tar_make()` waits at least 15 seconds befo
 
 ### Timestamps
 
-Another esoteric tip: `targets` uses hashes to check each target. These hashes are slow, and time stamps can speed up checks on [local data files](#data) in `_targets/objects/`. `tar_option_set(trust_object_timestamps = TRUE)` (already the default) opts into fast time stamps, and `tar_option_set(trust_object_timestamps = FALSE)` opts out. For similarly fast processing of [external file targets](#data), set `format = "file_fast"` instead of `format = "file"`.
+Another esoteric tip: `targets` can use hashes to check each target. These hashes are slow, and time stamps can speed up checks on [local data files](#data) in `_targets/objects/`. As such, targets defaults into checking if a target has been updated since the last time a pipeline ran, and assumes the target is up to date if not. You can opt out of using fast time stamps by using `tar_option_set(trust_object_timestamps = FALSE)` opts out, or explicitly opt in by using `tar_option_set(trust_object_timestamps = TRUE)`. For similarly fast processing of [external file targets](#data), set `format = "file_fast"` instead of `format = "file"`.
 
 ::: {.callout-important}
 ### Dangers of timestamps


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ ] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md). (I don't think there is one?)
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

Sorry, I skipped the issue because it was pretty fast to make an edit, which I think explains my issue better than I could in an issue.

# Summary

The `Timestamps` section of the performance chapter begins:

> Another esoteric tip: targets uses hashes to check each target

I think this is incorrect? Given the default `trust_object_timestamps = TRUE` setting, I _believe_ that targets is checking timestamps by default, and instead has the _option_ of checking hashes. I think this section would be improved by rephrasing the first sentence to make it clear that hashes are not the default behavior. This makes the section an odd fit for the performance chapter (since the performance tip is to not turn hashes on, I suppose?), but hopefully makes the default behavior more clear.
