### PR TITLE
Fix typo in argument name: sctore -> store

### DIFF
--- a/projects.qmd
+++ b/projects.qmd
@@ -157,9 +157,9 @@ Alternatively, you can manually select the appropriate script and store for each
 
 ```{r, eval = FALSE}
 tar_make(script = "script_a.R", store = "store_a")
-tar_read(target_abc, sctore = "store_a")
+tar_read(target_abc, store = "store_a")
 tar_make(script = "script_b.R", store = "store_b")
-tar_read(target_abc, sctore = "store_b")
+tar_read(target_abc, store = "store_b")
 ```
 
 ## Interdependent projects


### PR DESCRIPTION
# Prework

* [x] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ ] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
I think this was renamed to targets instead of targets-manual: so the new url is https://github.com/ropensci-books/targets/blob/main/CONTRIBUTING.md
* [ ] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #

# Summary

Fixing a typo
