### PR TITLE
Correct minor typos in  targets.qmd

### DIFF
--- a/targets.qmd
+++ b/targets.qmd
@@ -15,7 +15,7 @@ library(tarchetypes)
 
 # Targets {#targets}
 
-A target is a high-level steps of the computational pipeline, and it a piece of work that you define with your custom functions. A target runs some R code and saves the returned R object to storage, usually a single file inside `_targets/objects/`. 
+A target is a high-level step of the computational pipeline, and a piece of work that you define with your custom functions. A target runs some R code and saves the returned R object to storage, usually a single file inside `_targets/objects/`. 
 
 ## Target names
 


### PR DESCRIPTION


# Prework

* [x ] I understand and agree to this repository's [code of conduct](https://ropensci.org/code-of-conduct/).
* [ x] I understand and agree to this repository's [contributing guidelines](https://github.com/ropensci-boooks/targets-manual/blob/main/CONTRIBUTING.md).
* [ x] I have already submitted an issue to the [issue tracker](http://github.com/ropensci-boooks/targets-manual/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #

# Summary

I noticed two typos in the opening sentence of targets.qmd
